### PR TITLE
Fix: Improve password handling and security for user management

### DIFF
--- a/backend/handlers/user_handler.go
+++ b/backend/handlers/user_handler.go
@@ -19,7 +19,6 @@ func CreateUserHandler(c *gin.Context) {
 
 	// Simplificação: A senha deveria ser recebida em um campo separado e hasheada aqui.
 	// Por enquanto, estamos apenas simulando.
-	user.PasswordHash = "hashed_password_placeholder"
 
 	if err := services.CreateUser(&user); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro ao criar usuário"})

--- a/backend/handlers/user_handler_test.go
+++ b/backend/handlers/user_handler_test.go
@@ -8,10 +8,12 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/monteirobsb/user-management/backend/database"
 	"github.com/monteirobsb/user-management/backend/handlers"
 	"github.com/monteirobsb/user-management/backend/models"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/bcrypt"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -37,6 +39,8 @@ func setupRouter() *gin.Engine {
 	api := r.Group("/api/users")
 	{
 		api.POST("", handlers.CreateUserHandler)
+		api.PUT("/:id", handlers.UpdateUserHandler)
+		api.GET("/:id", handlers.GetUserHandler)
 	}
 	return r
 }
@@ -57,6 +61,57 @@ func TestCreateUserHandler(t *testing.T) {
 	json.Unmarshal(w.Body.Bytes(), &user)
 	assert.Equal(t, "Test User", user.Name)
 	assert.Equal(t, "test@example.com", user.Email)
-	assert.Empty(t, user.Password)        // Garante que a senha não foi retornada
-	assert.NotEmpty(t, user.PasswordHash) // Garante que o hash foi criado
+	assert.Empty(t, user.Password) // Garante que a senha não foi retornada
+	// PasswordHash não é mais retornado na resposta JSON
+}
+
+func TestUpdateUserPasswordHandler(t *testing.T) {
+	router := setupRouter()
+
+	// 1. Criar um novo usuário
+	initialPassword := "password123"
+	createUserPayload := map[string]string{
+		"name":     "Update Test User",
+		"email":    "update@example.com",
+		"password": initialPassword,
+	}
+	jsonPayload, _ := json.Marshal(createUserPayload)
+	reqCreate, _ := http.NewRequest("POST", "/api/users", bytes.NewBuffer(jsonPayload))
+	reqCreate.Header.Set("Content-Type", "application/json")
+
+	wCreate := httptest.NewRecorder()
+	router.ServeHTTP(wCreate, reqCreate)
+	assert.Equal(t, http.StatusCreated, wCreate.Code)
+
+	var createdUser models.User
+	err := json.Unmarshal(wCreate.Body.Bytes(), &createdUser)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, createdUser.ID)
+
+	userID := createdUser.ID
+
+	// 2. Atualizar a senha do usuário
+	newPassword := "newPassword456"
+	updatePasswordPayload := map[string]string{"password": newPassword}
+	jsonUpdatePayload, _ := json.Marshal(updatePasswordPayload)
+
+	reqUpdate, _ := http.NewRequest("PUT", "/api/users/"+userID.String(), bytes.NewBuffer(jsonUpdatePayload))
+	reqUpdate.Header.Set("Content-Type", "application/json")
+
+	wUpdate := httptest.NewRecorder()
+	router.ServeHTTP(wUpdate, reqUpdate)
+	assert.Equal(t, http.StatusOK, wUpdate.Code)
+
+	// 3. Verificar a atualização da senha no banco de dados
+	var updatedUser models.User
+	err = database.DB.First(&updatedUser, "id = ?", userID).Error
+	assert.NoError(t, err)
+
+	// Verificar se a senha antiga não corresponde mais
+	errOldPassword := bcrypt.CompareHashAndPassword([]byte(updatedUser.PasswordHash), []byte(initialPassword))
+	assert.Error(t, errOldPassword, "A senha antiga ainda corresponde, o que não deveria acontecer")
+
+	// Verificar se a nova senha corresponde
+	errNewPassword := bcrypt.CompareHashAndPassword([]byte(updatedUser.PasswordHash), []byte(newPassword))
+	assert.NoError(t, errNewPassword, "A nova senha não corresponde")
 }

--- a/backend/models/user.go
+++ b/backend/models/user.go
@@ -13,7 +13,7 @@ type User struct {
 	Name         string    `gorm:"size:255;not null" json:"name" binding:"required"`
 	Email        string    `gorm:"size:255;not null;unique" json:"email" binding:"required,email"`
 	Password     string    `gorm:"-" json:"password,omitempty" binding:"omitempty,min=8"` // omitempty para edição, min=8 para criação
-	PasswordHash string    `gorm:"not null" json:"password_hash"`
+	PasswordHash string    `gorm:"not null" json:"-"`
 	CreatedAt    time.Time `gorm:"not null" json:"created_at"`
 	UpdatedAt    time.Time `gorm:"not null" json:"updated_at"`
 }

--- a/backend/services/user_service.go
+++ b/backend/services/user_service.go
@@ -36,6 +36,15 @@ func GetUserByID(id uuid.UUID) (models.User, error) {
 
 // UpdateUser atualiza os dados de um usuário existente.
 func UpdateUser(user *models.User, id uuid.UUID) error {
+	if user.Password != "" {
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(user.Password), bcrypt.DefaultCost)
+		if err != nil {
+			return err
+		}
+		user.PasswordHash = string(hashedPassword)
+		user.Password = "" // Limpa a senha em texto plano
+	}
+
 	result := database.DB.Model(&models.User{}).Where("id = ?", id).Updates(user)
 	return result.Error
 }


### PR DESCRIPTION
This commit addresses several issues related to your user password management:

1.  **Prevent Password Hash Exposure**: The `PasswordHash` field in the `User` model is now tagged with `json:"-"`. This prevents the password hash from being inadvertently exposed in API responses (e.g., on user creation, retrieval, or listing).

2.  **Enable Password Updates**: The `UpdateUser` service logic has been modified to correctly handle password updates. If a `password` is provided in the update request, it will now be securely hashed and stored, replacing the old password hash. The plain text password is cleared after hashing.

3.  **Refactor Password Hashing in Creation**: Removed a misleading placeholder assignment for `PasswordHash` in `CreateUserHandler`. The actual password hashing is, and was correctly, performed in the `CreateUser` service. This change makes the handler code clearer.

4.  **Add Password Update Tests**: A new test case, `TestUpdateUserPasswordHandler`, has been added to `user_handler_test.go`. This test verifies that:
    - A user's password can be updated via the PUT `/api/users/{id}` endpoint.
    - The old password no longer works after an update.
    - The new password works (verified by comparing hashes directly from the DB). The existing `TestCreateUserHandler` was also adjusted to reflect that the password hash is no longer part of the API response. The test router was updated to include the PUT user endpoint.

These changes enhance the security and robustness of your user management functionality.